### PR TITLE
confetti autoStart fix-up

### DIFF
--- a/common.d.ts
+++ b/common.d.ts
@@ -13,5 +13,6 @@ export declare abstract class ConfettiViewBase extends ContentView {
     colors: Array<any>;
     intensity: number;
     fullScreen: boolean;
+    autoStart: boolean;
     readonly confetti: any;
 }

--- a/common.ts
+++ b/common.ts
@@ -23,5 +23,9 @@ export abstract class ConfettiViewBase extends ContentView {
 
   public get fullScreen() { return false; }
 
+  public set autoStart(value: boolean) { }
+
+  public get autoStart() { return false; }
+  
   public get confetti() { return null; }
 }

--- a/confetti-view.android.d.ts
+++ b/confetti-view.android.d.ts
@@ -8,8 +8,6 @@ export declare class ConfettiView extends ConfettiViewBase {
     private _autoStart;
     private _fullScreen;
     private _colors;
-    constructor();
-    createNativeView(): any;
     initNativeView(): void;
     destroyNativeView(): void;
     startConfetti(): void;
@@ -18,6 +16,6 @@ export declare class ConfettiView extends ConfettiViewBase {
     colors: Array<string>;
     intensity: number;
     fullScreen: boolean;
+    autoStart: boolean;
     readonly confetti: any;
-    onLayout(left: number, top: number, right: number, bottom: number): void;
 }

--- a/confetti-view.android.ts
+++ b/confetti-view.android.ts
@@ -73,5 +73,9 @@ export class ConfettiView extends ConfettiViewBase {
 
   public get fullScreen(): boolean { return false; }
 
+  public set autoStart(value: boolean) { }
+
+  public get autoStart(): boolean { return false; }
+
   public get confetti(): any { return this._confetti; }
 }

--- a/confetti-view.ios.d.ts
+++ b/confetti-view.ios.d.ts
@@ -15,5 +15,6 @@ export declare class ConfettiView extends ConfettiViewBase {
     colors: Array<any>;
     intensity: number;
     fullScreen: boolean;
+    autoStart: boolean;
     readonly confetti: any;
 }

--- a/confetti-view.ios.ts
+++ b/confetti-view.ios.ts
@@ -22,7 +22,7 @@ export class ConfettiView extends ConfettiViewBase {
     private _confetti: any;
     private _intensity: number = 0.5;
     private _active: boolean = false;
-    private _autoStart: boolean = true;
+    private _autoStart: boolean = false;
     private _fullScreen: boolean = false;
 
     createNativeView() {
@@ -41,9 +41,14 @@ export class ConfettiView extends ConfettiViewBase {
     initNativeView() {
         const confetti = this._confetti || this.nativeView;
         confetti.colors = this._colors;
-        confetti.itensity = this._intensity;
+        confetti.intensity = this._intensity;
+        confetti.autoStart = this._autoStart;
+        confetti.fullScreen = this._fullScreen;
         if (this._autoStart) {
             this.startConfetti();
+        }
+        else {
+            this.stopConfetti();
         }
     }
 
@@ -90,6 +95,14 @@ export class ConfettiView extends ConfettiViewBase {
 
     public get fullScreen() {
         return this._fullScreen;
+    }
+
+    public set autoStart(value: boolean) {
+        this._autoStart = value;
+    }    
+
+    public get autoStart() {
+        return this._autoStart;
     }
 
     public get confetti() {

--- a/demo-ng/app/item/items.component.html
+++ b/demo-ng/app/item/items.component.html
@@ -1,9 +1,11 @@
 <ActionBar title="My App" class="action-bar">
 </ActionBar>
 <StackLayout class="page">
-    <ConfettiView height="300" width="100%">
+    <ConfettiView #confetti height="300" width="100%" autoStart="true">
         <StackLayout class="p-10">
             <Label text="Can be embedded." textWrap="true"></Label>
+            <Button text="Start Confetti" (tap)="startConfetti()"></Button>
+            <Button text="Stop Confetti" (tap)="stopConfetti()"></Button>
             <Label text="Or tap an item below for full screen." textWrap="true"></Label>
         </StackLayout>
     </ConfettiView>

--- a/demo-ng/app/item/items.component.ts
+++ b/demo-ng/app/item/items.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, ElementRef, ViewChild } from "@angular/core";
 
 import { Item } from "./item";
 import { ItemService } from "./item.service";
@@ -10,6 +10,8 @@ import { ItemService } from "./item.service";
 })
 export class ItemsComponent implements OnInit {
     items: Item[];
+    //confetti
+    @ViewChild("confetti") confetti: ElementRef;
 
     // This pattern makes use of Angular’s dependency injection implementation to inject an instance of the ItemService service into this class. 
     // Angular knows about this service because it is included in your app’s main NgModule, defined in app.module.ts.
@@ -17,5 +19,13 @@ export class ItemsComponent implements OnInit {
 
     ngOnInit(): void {
         this.items = this.itemService.getItems();
+    }
+
+    startConfetti() {
+        this.confetti.nativeElement.startConfetti();
+    }
+    
+    stopConfetti() {
+        this.confetti.nativeElement.stopConfetti();
     }
 }

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -4,7 +4,7 @@
     loaded="loaded"
     navigatingTo="navigatingTo">
     <StackLayout class="w-full h-full">
-        <confetti:ConfettiView id="confetti" colors="{{ colors }}">
+        <confetti:ConfettiView id="confetti">
             <StackLayout id="container" class="inner-content p-20">
                 <Label text="It's raining confetti!" class="message" textWrap="true"/>
                 <Button text="Stop Confetti" tap="{{ stopConfetti }}"/>


### PR DESCRIPTION
The autoStart functionality wasn't quite working prior, so I have added that functionality. I think there are still issues with intensity (fixed typo), type of confetti, and colors, but I'm going to concentrate in this PR wtih autoStart. Setting it to 'false' by default will help manage it better either from the xml or from the component or code-behind. The behavior of this plugin on Angular is a little strange (confetti from the side, vs. from the top) so managing autoStart properly will help make it perform better on Angular